### PR TITLE
Query hapi

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,2 +1,3 @@
 FLASK_ENV=development
 FLASK_APP=map.app:create_app
+HAPI_URL=https://hapi-fhir.cirg.washington.edu/hapi-fhir-jpaserver/fhir/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN mkdir /code
 WORKDIR /code
 
 COPY . /code/
+RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 RUN pip install -e .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # WARNING: this file is not suitable for production, please use with caution
-version: '3'
+version: '3.4'
 
 services:
   web:
@@ -15,3 +15,17 @@ services:
       - ./db/:/db/
     ports:
       - "${EXTERNAL_PORT}:5000"
+  couch:
+    image: couchdb:2.3.1
+    environment:
+      COUCHDB_USER: couchdb_user
+      # read from .env
+      COUCHDB_SECRET: ${COUCHDB_SECRET:-couchdb_secret}
+    ports:
+      - "5984:5984"
+    volumes:
+      - source: couchdb-data
+        target: /opt/couchdb/data
+        type: volume
+volumes:
+  couchdb-data: {}

--- a/map/api/resources/__init__.py
+++ b/map/api/resources/__init__.py
@@ -1,7 +1,10 @@
+from .fhir_resource import FhirResource, FhirSearch
 from .user import UserResource, UserList
 
 
 __all__ = [
+    'FhirSearch',
+    'FhirResource',
     'UserResource',
     'UserList'
 ]

--- a/map/api/resources/fhir_resource.py
+++ b/map/api/resources/fhir_resource.py
@@ -1,0 +1,56 @@
+from enum import Enum, auto
+from flask import request
+from flask_restful import Resource
+import requests
+from werkzeug.exceptions import BadRequest
+
+from map.fhir import HapiRequest
+
+
+class NameEnum(Enum):
+    """Mechanism to auto generate enum values using enum.name"""
+    def _generate_next_value_(name, start, count, last_values):
+        return name
+
+
+class ResourceType(NameEnum):
+    """Enumeration of supported FHIR resourceTypes"""
+    # Extend as needed, controlled to prevent abuse of the API
+    CarePlan = auto()
+    Encounter = auto()
+    Observation = auto()
+    Patient = auto()
+    Procedure = auto()
+    Questionnaire = auto()
+    QuestionnaireResponse = auto()
+
+    @classmethod
+    def validate(cls, value):
+        """validate given value is in ResourceType enumeration"""
+        if value in cls.__members__:
+            return True
+        raise BadRequest(f"{value} not a supported FHIR resourceType")
+
+
+class FhirSearch(Resource):
+    """Search by parameters, return bundle resource of requested resourceType
+    """
+    def get(self, resource_type):
+        ResourceType.validate(resource_type)
+        params = {'_pretty': 'true', '_format': 'json'}
+        params.update(request.args)
+        hapi_pat = requests.get(HapiRequest.build_request(
+            resource_type),
+            params=params)
+        return hapi_pat.json()
+
+
+class FhirResource(Resource):
+    """Single FHIR resource
+    """
+    def get(self, resource_type, patient_id):
+        ResourceType.validate(resource_type)
+        hapi_pat = requests.get(HapiRequest.build_request(
+            f"{resource_type}/{patient_id}"),
+            params={'_pretty': 'true', '_format': 'json'})
+        return hapi_pat.json()

--- a/map/api/views.py
+++ b/map/api/views.py
@@ -1,12 +1,21 @@
 from flask import Blueprint
 from flask_restful import Api
 
-from map.api.resources import UserResource, UserList
+from map.api.resources import (
+    FhirResource,
+    FhirSearch,
+    UserResource,
+    UserList,
+)
 
 
-blueprint = Blueprint('api', __name__, url_prefix='/api/v1')
+# naming the supported FHIR version, r4
+# see https://www.hl7.org/fhir/history.html
+blueprint = Blueprint('api', __name__, url_prefix='/api/r4')
 api = Api(blueprint)
 
 
+api.add_resource(FhirResource, '/<string:resource_type>/<int:patient_id>')
+api.add_resource(FhirSearch, '/<string:resource_type>')
 api.add_resource(UserResource, '/users/<int:user_id>')
 api.add_resource(UserList, '/users')

--- a/map/config.py
+++ b/map/config.py
@@ -5,6 +5,7 @@ Use env var to override
 import os
 
 ENV = os.getenv("FLASK_ENV")
+HAPI_URL = os.getenv("HAPI_URL")
 SERVER_NAME = os.getenv("SERVER_NAME")
 DEBUG = ENV == "development"
 SECRET_KEY = os.getenv("SECRET_KEY")

--- a/map/fhir/__init__.py
+++ b/map/fhir/__init__.py
@@ -1,0 +1,6 @@
+from .hapi import HapiRequest
+
+
+__all__ = [
+    'HapiRequest',
+]

--- a/map/fhir/hapi.py
+++ b/map/fhir/hapi.py
@@ -1,0 +1,17 @@
+from flask import current_app
+
+
+class HapiMeta(type):
+    """Meta class used for delayed init - need configured app"""
+    @property
+    def base_url(cls):
+        if getattr(cls, '_base_url', None) is None:
+            cls._base_url = current_app.config.get("HAPI_URL")
+        return cls._base_url
+
+
+class HapiRequest(metaclass=HapiMeta):
+
+    @classmethod
+    def build_request(cls, path):
+        return cls.base_url + path

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ flask-jwt-extended
 marshmallow-sqlalchemy
 python-dotenv
 passlib
+requests
 tox


### PR DESCRIPTION
Incorporated a few clever views to wrap all the desired FHIR resourceTypes.

Requests such as the following are behaving well:
```
/api/r4/Patient/23
/api/r4/CarePlan/54
/api/r4/QuestionnaireResponse/87
```
and searches like:
`/api/r4/Patient?identifier=keycloak|0df3e0be-bfd0-4602-b180-c3f1bb96b602`