### PR TITLE
OAuth2 proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,15 @@
 # note that celery will require a running broker and result backend
 FROM python:3.7
 
+ENV FLASK_APP=map.app:create_app \
+    FLASK_ENV=development
+
 RUN mkdir /code
 WORKDIR /code
 
 COPY . /code/
-RUN pip install --upgrade pip
+
 RUN pip install -r requirements.txt
-RUN pip install -e .
 
 CMD flask run --host 0.0.0.0
 

--- a/auth_proxy.env.default
+++ b/auth_proxy.env.default
@@ -7,3 +7,8 @@ SECRET_KEY=
 SERVER_NAME=localtest.me:5000
 
 HAPI_URL=
+
+# JSON Web Key Set from Authorization server jwks_uri
+# /auth/realms/Stayhome/.well-known/openid-configuration
+# /auth/realms/Stayhome/protocol/openid-connect/certs
+AUTHZ_JWKS_JSON=

--- a/auth_proxy.env.default
+++ b/auth_proxy.env.default
@@ -1,0 +1,9 @@
+# docker-compose default environment file
+# copy to auth_proxy.env and modify as necessary
+
+SECRET_KEY=
+
+# FQDN necessary for cookies; maps to 127.0.0.1
+SERVER_NAME=localtest.me:5000
+
+HAPI_URL=

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+---
+version: "3.4"
+services:
+  web:
+    build:
+      context: .
+    volumes:
+      #- ./:/opt/app
+      - ./map:/code/map
+    ports:
+      # allow override of published port
+      - ${EXTERNAL_PORT:-5000}:5000
+    env_file:
+      - auth_proxy.env

--- a/map/api/resources/fhir_resource.py
+++ b/map/api/resources/fhir_resource.py
@@ -32,13 +32,13 @@ class FhirSearch(Resource):
         try:
             ResourceType.validate(resource_type)
         except ValueError as e:
-            raise BadRequest(str())
+            raise BadRequest(str(e))
 
         bearer_token = request.headers['Authorization'].split()[-1]
         try:
             payload = validate_jwt(bearer_token)
         except (ExpiredSignatureError, JWTClaimsError) as e:
-            raise BadRequest(str())
+            raise BadRequest(str(e))
         else:
             current_app.logger.debug('JWT payload: %s', payload)
 
@@ -60,7 +60,7 @@ class FhirResource(Resource):
         try:
             payload = validate_jwt(bearer_token)
         except (ExpiredSignatureError, JWTClaimsError) as e:
-            raise BadRequest(str())
+            raise BadRequest(str(e))
         else:
             current_app.logger.debug('JWT payload: %s', payload)
 

--- a/map/config.py
+++ b/map/config.py
@@ -10,6 +10,7 @@ API_PREFIX = '/api/r4'
 
 ENV = os.getenv("FLASK_ENV")
 HAPI_URL = os.getenv("HAPI_URL")
+AUTHZ_JWKS_JSON = os.getenv("AUTHZ_JWKS_JSON")
 SERVER_NAME = os.getenv("SERVER_NAME")
 DEBUG = ENV == "development"
 SECRET_KEY = os.getenv("SECRET_KEY")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ jmespath
 marshmallow-sqlalchemy
 python-dateutil
 python-dotenv
+python-jose[cryptography]
 passlib
 requests
 tox


### PR DESCRIPTION
#### Changes
* Use [`python-jose`](https://github.com/mpdavis/python-jose/) to validate bearer tokens (JWT) from Keycloak
  * Set `AUTHZ_JWKS_JSON` as JSON string with [Keycloak data](https://keycloak-dev.cirg.washington.edu/auth/realms/Stayhome/protocol/openid-connect/certs)
* Add alternative docker-compose file for oauth2 proxy config

#### Todo:

- [ ] Investigate audience claim validation error
- [ ] Investigate using smaller `jwt` module
