### PR TITLE
HAPI FHIR Services

### DIFF
--- a/docker-compose.hapi.yaml
+++ b/docker-compose.hapi.yaml
@@ -1,0 +1,22 @@
+# HAPI FHIR group of services
+# extends docker-compose.yaml
+---
+version: "3.4"
+services:
+  hapi:
+    image:
+      "${DOCKER_REPOSITORY-docker.pkg.github.com/uwcirg/hapi-fhir-oauth2-starter/}${DOCKER_IMAGE_NAME:-hapi-fhir-jpa}:${DOCKER_IMAGE_TAG:-latest}"
+    depends_on:
+      - hapi-db
+  hapi-db:
+    image: postgres:${POSTGRES_VERSION:-12}
+    environment:
+      POSTGRES_DB: hapifhir
+      POSTGRES_USER: hapifhir
+      POSTGRES_PASSWORD: hapifhir
+    volumes:
+      - source: postgres-data
+        target: /var/lib/postgresql/data
+        type: volume
+volumes:
+    postgres-data: {}

--- a/docker-compose.hapi.yaml
+++ b/docker-compose.hapi.yaml
@@ -5,10 +5,10 @@ version: "3.4"
 services:
   hapi:
     image:
-      "${DOCKER_REPOSITORY-docker.pkg.github.com/uwcirg/hapi-fhir-oauth2-starter/}${DOCKER_IMAGE_NAME:-hapi-fhir-jpa}:${DOCKER_IMAGE_TAG:-latest}"
+      "${DOCKER_REPOSITORY-uwcirg/}${DOCKER_IMAGE_NAME:-hapi-fhir-oauth2-starter}:${DOCKER_IMAGE_TAG:-latest}"
     depends_on:
-      - hapi-db
-  hapi-db:
+      - db
+  db:
     image: postgres:${POSTGRES_VERSION:-12}
     environment:
       POSTGRES_DB: hapifhir


### PR DESCRIPTION
* Add HAPI FHIR JPA server and postgres DB
  * No ports exposed, network access only from docker network

To configure, set the below environment variable in the `.env` file:
```
COMPOSE_FILE=docker-compose.yaml:docker-compose.hapi.yaml
```
To test the HAPI server from map-api (`web container`), curl is helpful:
```
dc exec web curl hapi:8080/hapi-fhir-jpaserver/fhir/Patient/23?_format=json
```