### PR TITLE
Enable unauthorized read of Communication resources

### DIFF
--- a/map/authz/authorizeduser.py
+++ b/map/authz/authorizeduser.py
@@ -83,6 +83,22 @@ class AuthzCheckCommunication(AuthzCheckResource):
     def __init__(self, authz_user, fhir_resource):
         super().__init__(authz_user, fhir_resource)
 
+    def unauth_read(self):
+        """Communication with matching identifier available for reads
+
+        The configured `category` is used to tag Communications displayed
+        prior to login - allow access if present.
+
+        """
+        open_communication = current_app.config.get("CODE_SYSTEM")[
+            'open_communication']
+        for i in self.resource.get('category', []):
+            for coding in i['coding']:
+                if coding == open_communication:
+                    return True
+
+        raise Unauthorized("Unauthorized 'category' not found")
+
     def write(self):
         """Initial writes allowed, and updates if same patient"""
         # allow for time being

--- a/map/config.py
+++ b/map/config.py
@@ -8,6 +8,13 @@ import os
 # see https://www.hl7.org/fhir/history.html
 API_PREFIX = '/api/r4'
 
+CODE_SYSTEM = {
+    'open_communication': {
+        'system': "https://stayhome.app/CodeSystem/communication-category",
+        'code': "system-announcement"
+    }
+}
+
 ENV = os.getenv("FLASK_ENV")
 HAPI_URL = os.getenv("HAPI_URL")
 AUTHZ_JWKS_JSON = os.getenv("AUTHZ_JWKS_JSON")


### PR DESCRIPTION
but only if the configured Communication.category is present.

Fix for https://www.pivotaltracker.com/story/show/172236250