### PR TITLE
Add badge for docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # MAP API
 API service for MAP (Mobile Assistance for Patients) application client use
 
+[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/uwcirg/map-api?label=latest%20release&sort=semver)](https://hub.docker.com/repository/docker/uwcirg/map-api)
+
 ## Deploy MAP API
 Clone this repository, copy `default.env` to `.env` in the
 root and apply the appropriate values.


### PR DESCRIPTION
* Add docker image badge for easy ref to Docker Hub
  * Badge pulls **Docker Image Version (latest semver)** from shields.io