### PR TITLE
Feature/qr post fix

### DIFF
--- a/map/authz/authorizeduser.py
+++ b/map/authz/authorizeduser.py
@@ -163,7 +163,7 @@ class AuthzCheckPatient(AuthzCheckResource):
 
         # Org admin and staff can only view patients with consents
         # on the same organization
-        if 'org_admin' or 'org_staff' in self.user.roles:
+        if 'org_admin' in self.user.roles or 'org_staff' in self.user.roles:
             if (self.same_user() or
                     self.user.consented_same_org(self.resource)):
                 return self.resource

--- a/map/authz/authorizeduser.py
+++ b/map/authz/authorizeduser.py
@@ -77,8 +77,6 @@ class AuthzCheckCarePlan(AuthzCheckResource):
 
     def write(self):
         """Initial writes allowed, and updates if same patient"""
-        if not self.user.patient_id():
-            return self.resource
         if not self.owned:
             raise Unauthorized("Write CarePlan failed; mismatched owner")
         return self.resource
@@ -202,6 +200,7 @@ class AuthzCheckQuestionnaireResponse(AuthzCheckResource):
         if not self.owned:
             raise Unauthorized(
                 "Write QuestionnaireResponse failed; mismatched owner")
+        return self.resource
 
 
 def authz_check_resource(authz_user, resource):

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -33,6 +33,11 @@ def admin_jwt():
 
 
 @fixture
+def patient_jwt():
+    return generate_jwt()
+
+
+@fixture
 def org_staff_jwt():
     return generate_jwt(
         sub="6c9d2b3f-a674-4866-9b0c-da0020d36ca7", roles=('org_staff',))
@@ -67,6 +72,13 @@ def patient_1415(request):
         data = json.load(json_file)
     return data
 
+
+@fixture
+def qr_post_data(request):
+    data_dir, _ = os.path.splitext(request.module.__file__)
+    with open(os.path.join(data_dir, "qr_post.json"), 'r') as json_file:
+        data = json.load(json_file)
+    return data
 
 def test_patient_noauth(client, mocker, prefix, patient_bundle):
     """without auth header, should see 401"""
@@ -149,3 +161,21 @@ def test_consented_patients_query(
         'Authorization': 'Bearer {}'.format(org_staff_jwt)})
     assert len(results.json['entry']) == 1
     assert results.json['entry'][0]['resource']['id'] == "41"
+
+
+def test_qr_post(
+        client, mocker, patient_1415, patient_jwt, prefix, qr_post_data):
+
+    # mock results when looking up acting user's internal ids
+    mock_patient = mocker.patch('map.fhir.HapiRequest.find_one')
+    mock_patient.return_value = patient_1415, 200
+
+    # mock results when posting
+    mock_patient = mocker.patch('map.fhir.HapiRequest.post_resource')
+    mock_patient.return_value = {}, 200
+
+    results = client.post(
+        '/'.join((prefix, 'QuestionnaireResponse')),
+        headers={'Authorization': 'Bearer {}'.format(patient_jwt)},
+        json=qr_post_data)
+    assert results.status_code == 200

--- a/tests/test_authz/qr_post.json
+++ b/tests/test_authz/qr_post.json
@@ -1,0 +1,88 @@
+{
+  "resourceType": "QuestionnaireResponse",
+  "questionnaire": "Questionnaire/1057",
+  "basedOn": [
+    {
+      "reference": "CarePlan/1189"
+    }
+  ],
+  "subject": {
+    "reference": "Patient/1415"
+  },
+  "authored": "2020-06-03T11:14:00.000",
+  "item": [
+    {
+      "linkId": "/exposure_confidence",
+      "answer": [
+        {
+          "valueCoding": {
+            "system": "Custom",
+            "code": "possible",
+            "display": "Possible",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                  "valueBoolean": true
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "mn"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "⠿⠿Possible~~"
+                    }
+                  ]
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Möglich"
+                    }
+                  ]
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Posible"
+                    }
+                  ]
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "fr"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Posib"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "status": "completed"
+}


### PR DESCRIPTION
The authorization check for writes to QuestionnaireResponse was in error - not returning the posted data after checking.
When filtering was added, a change was made to return data from authz checks, in case of filtering.  This PR resolves an oversight.